### PR TITLE
forgot to require the 'colorful' module

### DIFF
--- a/lib/detect-global.js
+++ b/lib/detect-global.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var spawn = require('win-spawn');
 var exists = fs.existsSync || path.existsSync;
+require('colorful').toxic();
 
 module.exports = function(code, callback) {
 


### PR DESCRIPTION
没有requrie colorful模块，导致后面的

``` js
console.log('Found global variables need to export: '.gray + variables.magenta);
```

输出NaN
